### PR TITLE
[lddtree.sh] Fixed Bad substitution if running in dash

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -214,7 +214,7 @@ show_elf() {
 		allhits="${allhits},${interp},${libs}"
 	fi
 
-	for lib in ${libs//,/ } ; do
+	for lib in $(echo $libs | tr ',' ' ') ; do
 		lib=${lib##*/}
 		case ",${my_allhits}," in
 			*,${lib},*) continue;;


### PR DESCRIPTION
Hello. =)
~$ bash -exc 'libs="abc,foo,bar";  for lib in ${libs//,/ }; do echo $lib; done'
~+ libs=abc,foo,bar
~+ for lib in '${libs//,/ }'
~+ echo abc
abc
~+ for lib in '${libs//,/ }'
~+ echo foo
foo
~+ for lib in '${libs//,/ }'
~+ echo bar
bar
~$ dash -exc 'libs="abc,foo,bar";  for lib in ${libs//,/ }; do echo $lib; done'
~+ libs=abc,foo,bar
dash: 1: Bad substitution
~~$ sh -exc 'libs="abc,foo,bar";  for lib in ${libs//,/ }; do echo $lib; done'
~+ libs=abc,foo,bar
sh: 1: Bad substitution
