### PR TITLE
Also redirect stderr to /dev/null when checking for backend

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -314,9 +314,9 @@ shift $(( $OPTIND - 1))
 
 ${SET_X} && set -x
 
-if which scanelf >/dev/null; then
+if which scanelf >/dev/null 2&>1; then
 	BACKEND=scanelf
-elif which objdump >/dev/null && which readelf >/dev/null; then
+elif which objdump >/dev/null 2&>1 && which readelf >/dev/null 2&>1; then
 	BACKEND=binutils
 else
 	error "This tool needs either scanelf or binutils (objdump and readelf)"


### PR DESCRIPTION
Without this change:

```
which: no scanelf in (~/bin:/opt/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin)
ls => /bin/ls (interpreter => /lib64/ld-linux-x86-64.so.2)
    libselinux.so.1 => /lib64/libselinux.so.1
        libpcre.so.1 => /lib64/libpcre.so.1
            libpthread.so.0 => /lib64/libpthread.so.0
        libdl.so.2 => /lib64/libdl.so.2
    libcap.so.2 => /lib64/libcap.so.2
        libattr.so.1 => /lib64/libattr.so.1
    libacl.so.1 => /lib64/libacl.so.1
    libc.so.6 => /lib64/libc.so.6
```

With this change:

```
ls => /bin/ls (interpreter => /lib64/ld-linux-x86-64.so.2)
    libselinux.so.1 => /lib64/libselinux.so.1
        libpcre.so.1 => /lib64/libpcre.so.1
            libpthread.so.0 => /lib64/libpthread.so.0
        libdl.so.2 => /lib64/libdl.so.2
    libcap.so.2 => /lib64/libcap.so.2
        libattr.so.1 => /lib64/libattr.so.1
    libacl.so.1 => /lib64/libacl.so.1
    libc.so.6 => /lib64/libc.so.6
```

