### PR TITLE
lddtree : prefer RUNPATH value over RPATH, if both are fixed

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -68,7 +68,7 @@ elf_specs_scanelf() {
 
 # functions for binutils backend
 elf_rpath_binutils() {
-	objdump -x "$@" | awk '$1 == "RPATH" || $1 == "RUNPATH" { print $2 }'
+	objdump -x "$@" | awk '$1 == "RUNPATH" { if($2!="") {runpath=$2;} }  $1 == "RPATH" { if($2!="") {rpath=$2;} } END { if(runpath!="") {print runpath;} else {print rpath;} }'
 }
 
 elf_interp_binutils() {


### PR DESCRIPTION
If both RUNPATH and RPATH are fixed, both values will be returned by elf_rpath_binutils.

* First, only one value should be returned, or the lddtree do not use any rpath value
* Second, when both values exist, RUNPATH must be privileged over RPATH value