### PR TITLE
Send usage to stderr instead of stdout

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -13,7 +13,7 @@ version=1.26
 [ "${ROOT}" = "${ROOT#/}" ] && ROOT="${PWD}/${ROOT}"
 
 usage() {
-	cat <<-EOF
+	cat >&2 <<-EOF
 	Display ELF dependencies as a tree
 
 	Usage: ${argv0} [options] <ELF file[s]>


### PR DESCRIPTION
Fixes problems if there's a problem with the usage of lddtree.sh and its output is piped into another program. Writing to stderr will make sure the usage message is shown to the user.