### PR TITLE
Escape arguments to find_elf() and show_elf(), to support directory names containing spaces.

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -107,7 +107,7 @@ c_ldso_paths_loaded='false'
 find_elf() {
 	_find_elf=''
 
-	local elf=$1 needed_by=$2
+	local elf="$1" needed_by="$2"
 	if [ "${elf}" != "${elf##*/}" ] && [ -e "${elf}" ] ; then
 		_find_elf=${elf}
 		return 0
@@ -215,7 +215,7 @@ resolv_links() {
 }
 
 show_elf() {
-	local elf=$1 indent=$2 parent_elfs=$3
+	local elf="$1" indent="$2" parent_elfs="$3"
 	local rlib lib libs
 	local interp resolved
 	find_elf "${elf}"


### PR DESCRIPTION
Without this, attempting to run lddtree.sh against a file in a folder with a space in its name (in my case, "Sid Meier's Civilization VI") gives an error like this:

`/path/to/lddtree.sh: 218: local: Meier's: bad variable name`