### PR TITLE
Fix POSIX sh compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Usage: lddtree.sh [options] ELFFILE...
 
 Options:
 
-  -a              Show all duplicated dependencies
-  -x              Run with debugging
-  -R <root>       Use this ROOT filesystem tree
-  --no-auto-root  Do not automatically prefix input ELFs with ROOT
-  -l              Display output in a flat format
-  -h              Show this help output
-  -V              Show version information
+  -a                  Show all duplicated dependencies
+  -x                  Run with debugging
+  -R <root>           Use this ROOT filesystem tree
+  -N, --no-auto-root  Do not automatically prefix input ELFs with ROOT
+  -l                  Display output in a flat format
+  -h                  Show this help output
+  -V                  Show version information
 ```


### PR DESCRIPTION
as lddtree uses /bin/sh as its hashbang, it cannot use bashisms

i'm not really happy about the long option workaround, but couldn't find a better way to still support it (used in alpine's mkinitfs and who knows where, cannot remove)

as for the indent - posix says "For other conversion specifiers, the behavior is undefined." when the precision argument is 0, so we should avoid that