### PR TITLE
lddtree: Respect LD_LIBRARY_PATH when resolving dependency

### DIFF
--- a/lddtree.sh
+++ b/lddtree.sh
@@ -136,7 +136,7 @@ find_elf() {
 		fi
 
 		if [ -n "${LD_LIBRARY_PATH}" ] ; then
-			check_paths "${elf}" "${LD_LIBRARY_PATH}"
+			check_paths "${elf}" "${LD_LIBRARY_PATH}" && return 0
 		fi
 
 		if ! ${c_ldso_paths_loaded} ; then


### PR DESCRIPTION
The code was not early returning after finding the correct elf along LD_LIBRARY_PATH, which resulted in incorrect libraries being returned, particularly if there was an alternate lib in the default system location.